### PR TITLE
kindof fix infinity on crossbow

### DIFF
--- a/packs/infinity_on_crossbow/data/minecraft/enchantment/infinity.json
+++ b/packs/infinity_on_crossbow/data/minecraft/enchantment/infinity.json
@@ -1,0 +1,40 @@
+{
+    "description": {
+      "translate": "enchantment.minecraft.infinity"
+    },
+    "exclusive_set": "#minecraft:exclusive_set/bow",
+    "supported_items": [
+      "minecraft:bow",
+      "minecraft:crossbow"
+    ],
+    "weight": 1,
+    "max_level": 1,
+    "min_cost": {
+      "base": 20,
+      "per_level_above_first": 0
+    },
+    "max_cost": {
+      "base": 50,
+      "per_level_above_first": 0
+    },
+    "anvil_cost": 8,
+    "slots": [
+      "mainhand"
+    ],
+    "effects": {
+      "minecraft:ammo_use": [
+        {
+          "effect": {
+            "type": "minecraft:set",
+            "value": 0
+          },
+          "requirements": {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "items": "minecraft:arrow"
+            }
+          }
+        }
+      ]
+    }
+}

--- a/packs/infinity_on_crossbow/data/minecraft/tags/enchantment/exclusive_set/bow.json
+++ b/packs/infinity_on_crossbow/data/minecraft/tags/enchantment/exclusive_set/bow.json
@@ -1,4 +1,0 @@
-{
-  "replace":true,
-  "values": []
-}


### PR DESCRIPTION
few things to note with this pr;
1. it might conflict with the other pack that touches the infinity enchantment because effects is defined here - no idea if all of the extra stuff is necessary and I did not perform adequate testing
2. supported_items apparently only accepts the actual items, not tags like you have in your other pack i just mentioned (I didn't test the other pack so I can't say for sure though - when trying to use a generator I encountered an error but the preset used the tag, but then when actually taking the time to test things a tag would not work at all).
3. pack only works when unzipped - no idea why

I hope this is a bit useful