### PR TITLE
Add recipe for Enchanted Golden Apple

### DIFF
--- a/packs/crafting/misc/enchanted_golden_apple/data/purpur/recipe/enchanted_golden_apple.json
+++ b/packs/crafting/misc/enchanted_golden_apple/data/purpur/recipe/enchanted_golden_apple.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "#": "minecraft:gold_block",
+    "X": "minecraft:apple"
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:enchanted_golden_apple"
+  }
+}


### PR DESCRIPTION
I would like to suggest the addition of a Purpur Pack which can be used to restore the removed crafting recipe for the Enchanted Golden Apple. I've already created a file which can be used to achieve this.